### PR TITLE
Prevent stack smash crash

### DIFF
--- a/pywiegand/extension/pywiegand_adapter.cpp
+++ b/pywiegand/extension/pywiegand_adapter.cpp
@@ -17,87 +17,71 @@ ISREntry ISRArray[4] = {
 };
 
 void ISR1(void) {
-  if (digitalRead(ISRArray[0].d1) == HIGH) {
-    if (ISRArray[0].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-      ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] <<= 1;
-      ISRArray[0].__wiegandBitCount++;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ISRArray[0].__wiegandBitTime);
+  if (ISRArray[0].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+    ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] <<= 1;
+    ISRArray[0].__wiegandBitCount++;
   }
+  clock_gettime(CLOCK_MONOTONIC, &ISRArray[0].__wiegandBitTime);
 }
 
 void ISR2(void) {
-  if (digitalRead(ISRArray[0].d0) == HIGH) {
-    if (ISRArray[0].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-      ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] <<= 1;
-      ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] |= 1;
-      ISRArray[0].__wiegandBitCount++;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ISRArray[0].__wiegandBitTime);
+  if (ISRArray[0].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+    ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] <<= 1;
+    ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] |= 1;
+    ISRArray[0].__wiegandBitCount++;
   }
+  clock_gettime(CLOCK_MONOTONIC, &ISRArray[0].__wiegandBitTime);
 }
 
 void ISR3(void) {
-  if (digitalRead(ISRArray[1].d1) == HIGH) {
-    if (ISRArray[1].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-      ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] <<= 1;
-      ISRArray[1].__wiegandBitCount++;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ISRArray[1].__wiegandBitTime);
+  if (ISRArray[1].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+    ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] <<= 1;
+    ISRArray[1].__wiegandBitCount++;
   }
+  clock_gettime(CLOCK_MONOTONIC, &ISRArray[1].__wiegandBitTime);
 }
 
 void ISR4(void) {
-  if (digitalRead(ISRArray[1].d0) == HIGH) {
-    if (ISRArray[1].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-      ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] <<= 1;
-      ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] |= 1;
-      ISRArray[1].__wiegandBitCount++;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ISRArray[1].__wiegandBitTime);
+  if (ISRArray[1].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+    ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] <<= 1;
+    ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] |= 1;
+    ISRArray[1].__wiegandBitCount++;
   }
+  clock_gettime(CLOCK_MONOTONIC, &ISRArray[1].__wiegandBitTime);
 }
 
 void ISR5(void) {
-  if (digitalRead(ISRArray[2].d1) == HIGH) {
-    if (ISRArray[2].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-      ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] <<= 1;
-      ISRArray[2].__wiegandBitCount++;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ISRArray[2].__wiegandBitTime);
+  if (ISRArray[2].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+    ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] <<= 1;
+    ISRArray[2].__wiegandBitCount++;
   }
+  clock_gettime(CLOCK_MONOTONIC, &ISRArray[2].__wiegandBitTime);
 }
 
 void ISR6(void) {
-  if (digitalRead(ISRArray[2].d0) == HIGH) {
-    if (ISRArray[2].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-      ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] <<= 1;
-      ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] |= 1;
-      ISRArray[2].__wiegandBitCount++;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ISRArray[2].__wiegandBitTime);
+  if (ISRArray[2].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+    ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] <<= 1;
+    ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] |= 1;
+    ISRArray[2].__wiegandBitCount++;
   }
+  clock_gettime(CLOCK_MONOTONIC, &ISRArray[2].__wiegandBitTime);
 }
 
 void ISR7(void) {
-  if (digitalRead(ISRArray[3].d1) == HIGH) {
-    if (ISRArray[3].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-      ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] <<= 1;
-      ISRArray[3].__wiegandBitCount++;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ISRArray[3].__wiegandBitTime);
+  if (ISRArray[3].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+    ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] <<= 1;
+    ISRArray[3].__wiegandBitCount++;
   }
+  clock_gettime(CLOCK_MONOTONIC, &ISRArray[3].__wiegandBitTime);
 }
 
 void ISR8(void) {
-  if (digitalRead(ISRArray[3].d0) == HIGH) {
-    if (ISRArray[3].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-      ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] <<= 1;
-      ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] |= 1;
-      ISRArray[3].__wiegandBitCount++;
-    }
-    clock_gettime(CLOCK_MONOTONIC, &ISRArray[3].__wiegandBitTime);
+  if (ISRArray[3].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+    ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] <<= 1;
+    ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] |= 1;
+    ISRArray[3].__wiegandBitCount++;
   }
+  clock_gettime(CLOCK_MONOTONIC, &ISRArray[3].__wiegandBitTime);
 }
 
 Wiegand::Wiegand() {
@@ -249,21 +233,28 @@ PyObject *IsInitialized(PyObject *self, PyObject *args) {
 
 PyObject *ReadData(PyObject *self, PyObject *args) {
   char data[WIEGANDMAXDATA];
-  char binstr[100];
+  char binstr[256];
   char bstr[9];
   int bitlen;
   int slen;
   int i;
+  size_t binstrsize;
   PyObject *wrCapsule_;
   PyArg_ParseTuple(args, "O", &wrCapsule_);
   Wiegand *WR = (Wiegand *)PyCapsule_GetPointer(wrCapsule_, "WRPtr");
   memset(&data[0], 0, WIEGANDMAXDATA);
   bitlen = WR->ReadData((void *)data, WIEGANDMAXDATA);
-  memset(&binstr[0], 0, 100);
+  binstrsize = sizeof(binstr);
+  memset(&binstr[0], 0, binstrsize);
   slen = (bitlen / 8 + 1);
   for (i = 0; i < slen; i++) {
     WR->PrintBinCharPad(data[i], bstr);
-    strcat(binstr, bstr);
+    if (strlen(binstr) + strlen(bstr) < binstrsize) {
+      strcat(binstr, bstr);
+    } else {
+      printf("Data overflow was truncated\n");
+      break;
+    }
   }
 
   return Py_BuildValue("si", binstr, bitlen);

--- a/pywiegand/extension/pywiegand_adapter.cpp
+++ b/pywiegand/extension/pywiegand_adapter.cpp
@@ -17,71 +17,87 @@ ISREntry ISRArray[4] = {
 };
 
 void ISR1(void) {
-  if (ISRArray[0].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-    ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] <<= 1;
-    ISRArray[0].__wiegandBitCount++;
+  if (digitalRead(ISRArray[0].d1) == HIGH) {
+    if (ISRArray[0].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+      ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] <<= 1;
+      ISRArray[0].__wiegandBitCount++;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &ISRArray[0].__wiegandBitTime);
   }
-  clock_gettime(CLOCK_MONOTONIC, &ISRArray[0].__wiegandBitTime);
 }
 
 void ISR2(void) {
-  if (ISRArray[0].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-    ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] <<= 1;
-    ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] |= 1;
-    ISRArray[0].__wiegandBitCount++;
+  if (digitalRead(ISRArray[0].d0) == HIGH) {
+    if (ISRArray[0].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+      ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] <<= 1;
+      ISRArray[0].__wiegandData[ISRArray[0].__wiegandBitCount / 8] |= 1;
+      ISRArray[0].__wiegandBitCount++;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &ISRArray[0].__wiegandBitTime);
   }
-  clock_gettime(CLOCK_MONOTONIC, &ISRArray[0].__wiegandBitTime);
 }
 
 void ISR3(void) {
-  if (ISRArray[1].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-    ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] <<= 1;
-    ISRArray[1].__wiegandBitCount++;
+  if (digitalRead(ISRArray[1].d1) == HIGH) {
+    if (ISRArray[1].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+      ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] <<= 1;
+      ISRArray[1].__wiegandBitCount++;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &ISRArray[1].__wiegandBitTime);
   }
-  clock_gettime(CLOCK_MONOTONIC, &ISRArray[1].__wiegandBitTime);
 }
 
 void ISR4(void) {
-  if (ISRArray[1].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-    ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] <<= 1;
-    ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] |= 1;
-    ISRArray[1].__wiegandBitCount++;
+  if (digitalRead(ISRArray[1].d0) == HIGH) {
+    if (ISRArray[1].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+      ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] <<= 1;
+      ISRArray[1].__wiegandData[ISRArray[1].__wiegandBitCount / 8] |= 1;
+      ISRArray[1].__wiegandBitCount++;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &ISRArray[1].__wiegandBitTime);
   }
-  clock_gettime(CLOCK_MONOTONIC, &ISRArray[1].__wiegandBitTime);
 }
 
 void ISR5(void) {
-  if (ISRArray[2].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-    ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] <<= 1;
-    ISRArray[2].__wiegandBitCount++;
+  if (digitalRead(ISRArray[2].d1) == HIGH) {
+    if (ISRArray[2].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+      ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] <<= 1;
+      ISRArray[2].__wiegandBitCount++;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &ISRArray[2].__wiegandBitTime);
   }
-  clock_gettime(CLOCK_MONOTONIC, &ISRArray[2].__wiegandBitTime);
 }
 
 void ISR6(void) {
-  if (ISRArray[2].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-    ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] <<= 1;
-    ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] |= 1;
-    ISRArray[2].__wiegandBitCount++;
+  if (digitalRead(ISRArray[2].d0) == HIGH) {
+    if (ISRArray[2].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+      ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] <<= 1;
+      ISRArray[2].__wiegandData[ISRArray[2].__wiegandBitCount / 8] |= 1;
+      ISRArray[2].__wiegandBitCount++;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &ISRArray[2].__wiegandBitTime);
   }
-  clock_gettime(CLOCK_MONOTONIC, &ISRArray[2].__wiegandBitTime);
 }
 
 void ISR7(void) {
-  if (ISRArray[3].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-    ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] <<= 1;
-    ISRArray[3].__wiegandBitCount++;
+  if (digitalRead(ISRArray[3].d1) == HIGH) {
+    if (ISRArray[3].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+      ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] <<= 1;
+      ISRArray[3].__wiegandBitCount++;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &ISRArray[3].__wiegandBitTime);
   }
-  clock_gettime(CLOCK_MONOTONIC, &ISRArray[3].__wiegandBitTime);
 }
 
 void ISR8(void) {
-  if (ISRArray[3].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
-    ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] <<= 1;
-    ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] |= 1;
-    ISRArray[3].__wiegandBitCount++;
+  if (digitalRead(ISRArray[3].d0) == HIGH) {
+    if (ISRArray[3].__wiegandBitCount / 8 < WIEGANDMAXDATA) {
+      ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] <<= 1;
+      ISRArray[3].__wiegandData[ISRArray[3].__wiegandBitCount / 8] |= 1;
+      ISRArray[3].__wiegandBitCount++;
+    }
+    clock_gettime(CLOCK_MONOTONIC, &ISRArray[3].__wiegandBitTime);
   }
-  clock_gettime(CLOCK_MONOTONIC, &ISRArray[3].__wiegandBitTime);
 }
 
 Wiegand::Wiegand() {
@@ -103,7 +119,7 @@ int Wiegand::Begin(int d0pin, int d1pin) {
       printf("Unable to init wiringPI");
       return 0;
     }
-    switch (this->m_isrord) {
+    switch (this->x) {
     case 0:
       ISRArray[this->m_isrord].isrd0 = &ISR1;
       ISRArray[this->m_isrord].isrd1 = &ISR2;

--- a/pywiegand/extension/pywiegand_adapter.cpp
+++ b/pywiegand/extension/pywiegand_adapter.cpp
@@ -119,7 +119,7 @@ int Wiegand::Begin(int d0pin, int d1pin) {
       printf("Unable to init wiringPI");
       return 0;
     }
-    switch (this->x) {
+    switch (this->m_isrord) {
     case 0:
       ISRArray[this->m_isrord].isrd0 = &ISR1;
       ISRArray[this->m_isrord].isrd1 = &ISR2;


### PR DESCRIPTION
When removing power from wiegand device or having intermittent contact with D0 or D1, garbage data can be picked up by ISRs. This can lead to strings being overflowed in ReadData since strcat is being used without length checks. Since I guess the default build parameters for the compiler are to guard the stack (a good thing I suppose), a stack smash error is received and it crashes Python.

One thing that I still struggle with is...if I get the source down on my device and do a `poetry build`, how do I get `pip install` to copy the newly built .so extension into the virtual environment directory? It currently won't and I don't know why. I have to manually copy it...

Also note that poetry has a dependency that depends on Rust (why?...not your problem I know...). This is a recent thing based on reading their bug log, and may be corrected. In the mean time, those dependencies have other dependencies (like libssl-dev, cffi-dev, and a few others I can't remember) that are not satisfied by the poetry installer. Thus installing poetry on a device like RPi is a pain in the neck and took me hours. FYI.

Python3 and associated tools are far from simplicity these days...

Also note that I originally suspected concurrency issues modifying the ISRArray data structures. If both lines go low simultaneously (which is not valid), I can see a potential for __wiegandBitCount to be subject to concurrent RW problems. Both lines going low are not supposed to yield a correct bit anyway. But I think spinlocks should be employed for predictable behavior. In any case, the actual bug was tracked down to ReadData and the binstr variable blowing out its size.

One idea I had was to cause the RPi pins to be pulled up. But what I noticed is that the keypad I was testing with, when the power was removed, the D0/D1 pins had a relatively low impedance to ground (like 4K or so, if I remember right). I would have expected them to float. So that would not have solved the problem as the voltage most likely would still appear as logic low.

Finally, this change can cause a ValueError to be throw by Python when doing a WiegandReader.read() since the data being converted might contain junk (not a valid integers as expected). I am not sure if you care...I just put a try/except in my consuming code and ignore anything which contains garbage.